### PR TITLE
Initial Pescador Benchmark tests

### DIFF
--- a/minibench/samplers.py
+++ b/minibench/samplers.py
@@ -122,7 +122,7 @@ def one_npy_random_slice(fpath, shape, mmap_mode=None, **kwargs):
     data_shape = np.shape(np_data)
     # Generate a slice in the bounds of this data.
     for new_slice in random_slices(data_shape, shape, **kwargs):
-        yield np_data[new_slice]
+        yield {'X': np_data[new_slice]}
 
 
 def one_npz_random_slice(fpath, field, shape, **kwargs):
@@ -152,7 +152,7 @@ def one_npz_random_slice(fpath, field, shape, **kwargs):
     arc = np.load(fpath)
     arr_shape = np.shape(arc[field])
     for new_slice in random_slices(arr_shape, shape, **kwargs):
-        yield arc[field][new_slice]
+        yield {'X': arc[field][new_slice]}
 
 
 def one_h5py_random_slice(key, fp, shape, **kwargs):
@@ -186,7 +186,7 @@ def one_h5py_random_slice(key, fp, shape, **kwargs):
     dset = fp[key]
     arr_shape = dset.shape
     for new_slice in random_slices(arr_shape, shape, **kwargs):
-        yield dset[new_slice]
+        yield {'X': dset[new_slice]}
 
 
 def one_biggie_random_slice(key, stash, field, shape, **kwargs):
@@ -215,7 +215,7 @@ def one_biggie_random_slice(key, stash, field, shape, **kwargs):
     entity = stash.get(key)
     arr_shape = entity[field].shape
     for new_slice in random_slices(arr_shape, shape, **kwargs):
-        yield entity[field].slice(new_slice)
+        yield {'X': entity[field].slice(new_slice)}
 
 
 def mux_random_slice(sampler, collec, shape, working_size=10, lam=25,
@@ -263,3 +263,10 @@ def mux_random_slice(sampler, collec, shape, working_size=10, lam=25,
                         k=working_size, lam=lam, pool_weights=pool_weights,
                         with_replacement=with_replacement,
                         prune_empty_seeds=prune_empty_seeds, revive=revive)
+
+
+def zmq_random_slice(**kwargs):
+    """Thin wrapper on mux_random_slice which just adds zmq streaming to it."""
+    streamer = pescador.Streamer(mux_random_slice(**kwargs))
+    return pescador.zmq_stream(streamer)
+    # return streamer

--- a/minibench/tests/test_samplers.py
+++ b/minibench/tests/test_samplers.py
@@ -51,7 +51,7 @@ def test_one_npy_load_random_slice(npy_files):
             fpath, slice_shape, mmap_mode=None, max_count=max_count)
 
         for rand_slice in sampler:
-            assert rand_slice.shape == slice_shape
+            assert rand_slice['X'].shape == slice_shape
 
         # Get a few of a different shape
         slice_shape = (1, 20)
@@ -59,7 +59,7 @@ def test_one_npy_load_random_slice(npy_files):
             fpath, slice_shape, mmap_mode=None, max_count=max_count)
 
         for rand_slice in sampler:
-            assert rand_slice.shape == slice_shape
+            assert rand_slice['X'].shape == slice_shape
 
 
 def test_one_npy_memmap_random_slice(npy_files):
@@ -72,7 +72,7 @@ def test_one_npy_memmap_random_slice(npy_files):
             fpath, slice_shape, mmap_mode='r', max_count=max_count)
 
         for rand_slice in sampler:
-            assert rand_slice.shape == slice_shape
+            assert rand_slice['X'].shape == slice_shape
 
         # Get a few of a different shape
         slice_shape = (1, 20)
@@ -80,7 +80,7 @@ def test_one_npy_memmap_random_slice(npy_files):
             fpath, slice_shape, mmap_mode='r', max_count=max_count)
 
         for rand_slice in sampler:
-            assert rand_slice.shape == slice_shape
+            assert rand_slice['X'].shape == slice_shape
 
 
 def test_one_npz_load_random_slice(npz_files):
@@ -93,7 +93,7 @@ def test_one_npz_load_random_slice(npz_files):
             fpath, field, slice_shape, max_count=max_count)
 
         for rand_slice in slicer:
-            assert rand_slice.shape == slice_shape
+            assert rand_slice['X'].shape == slice_shape
 
         # Get a few of a different shape
         slice_shape = (1, 20)
@@ -101,7 +101,7 @@ def test_one_npz_load_random_slice(npz_files):
             fpath, field, slice_shape, max_count=max_count)
 
         for rand_slice in slicer:
-            assert rand_slice.shape == slice_shape
+            assert rand_slice['X'].shape == slice_shape
 
 
 def test_one_h5py_random_slice(h5py_file):
@@ -115,7 +115,7 @@ def test_one_h5py_random_slice(h5py_file):
             key, fp, slice_shape, max_count=max_count)
 
         for rand_slice in sampler:
-            assert rand_slice.shape == slice_shape
+            assert rand_slice['X'].shape == slice_shape
 
         # Get a few of a different shape
         slice_shape = (1, 20)
@@ -123,7 +123,7 @@ def test_one_h5py_random_slice(h5py_file):
             key, fp, slice_shape, max_count=max_count)
 
         for rand_slice in sampler:
-            assert rand_slice.shape == slice_shape
+            assert rand_slice['X'].shape == slice_shape
 
 
 def test_one_biggie_random_slice(stash_file):
@@ -138,7 +138,7 @@ def test_one_biggie_random_slice(stash_file):
             key, stash, field, slice_shape, max_count=max_count)
 
         for rand_slice in sampler:
-            assert rand_slice.shape == slice_shape
+            assert rand_slice['X'].shape == slice_shape
 
         # Get a few of a different shape
         slice_shape = (1, 20)
@@ -146,7 +146,7 @@ def test_one_biggie_random_slice(stash_file):
             key, stash, field, slice_shape, max_count=max_count)
 
         for rand_slice in sampler:
-            assert rand_slice.shape == slice_shape
+            assert rand_slice['X'].shape == slice_shape
 
 
 def test_mux_random_slice(npy_files):
@@ -158,4 +158,16 @@ def test_mux_random_slice(npy_files):
 
     # Run the sampler to exhaustion.
     for rand_slice in sampler:
-        assert rand_slice.shape == slice_shape
+        assert rand_slice['X'].shape == slice_shape
+
+
+def test_zmq_random_slice(npy_files):
+    slice_shape = (3, 2)
+    sampler = minibench.samplers.zmq_random_slice(
+        sampler=minibench.samplers.one_npy_random_slice,
+        collec=npy_files, shape=slice_shape,
+        max_count=3, with_replacement=False)
+
+    # Run the sampler to exhaustion.
+    for rand_slice in sampler:
+        assert rand_slice['X'].shape == slice_shape

--- a/testbench_gil.py
+++ b/testbench_gil.py
@@ -1,0 +1,92 @@
+"""Collection of benchmarking routines for tasks related testing
+minibatch generation with Pescador.
+
+Sample Calls
+------------
+To run the tests with a bit of verbosity...
+
+  $ py.test -vs testbench_gil.py \
+    --benchmark-min-rounds=100 \
+    --benchmark-sort=mean
+
+Optionally, you can direct the test to preserve the temporary data generated
+during the tests...
+
+  $ py.test -vs --no-clean testbench_performance.py
+
+
+You need to run it with the --benchmark-save=foobar parameter
+for to successfully generate a json output file.
+
+  $ py.test -vs testbench_performance.py --benchmark-save=bench1
+"""
+import biggie
+import h5py
+import logging
+import pytest
+
+import minibench
+
+logging.basicConfig(level=logging.INFO)
+
+
+def heavy_cpu_fx(x):
+    for n in range(1000):
+        np.power(np.sqrt(np.abs(np.fft(x))), 2)
+        # You could sleep here or not just for fun / extra cycles.
+    return x
+
+
+def example_training_loop(sampler, train):
+    """
+    Parameters
+    ----------
+    sampler : generator
+        Generator which yields np.ndarrays
+
+    train : function
+        A do-the-thing funciton that uses CPU cycles.
+    """
+    # Get some data to start with
+    working_data = next(sampler)
+
+    for next_data in sampler:
+        err = train(working_data)
+
+        working_data = next_data
+
+    return err
+
+
+
+
+# def test_npy_load(benchmark, npys_params):
+#     npy_files, params = npys_params
+
+#     sampler = minibench.samplers.mux_random_slice(
+#         sampler=minibench.samplers.one_npy_random_slice,
+#         collec=npy_files,
+#         shape=params['slice'],
+#         n_samples=None,
+#         lam=params['lam'],
+#         working_size=params['working_size'],
+#         with_replacement=True)
+#     obs = benchmark(next, sampler)
+#     assert obs.shape == tuple(params['slice'])
+
+
+# def test_npy_memmap(benchmark, npys_params):
+#     npy_files, params = npys_params
+#     sampler = minibench.samplers.mux_random_slice(
+#         sampler=minibench.samplers.one_npy_random_slice,
+#         collec=npy_files,
+#         shape=params['slice'],
+#         n_samples=None,
+#         lam=params['lam'],
+#         working_size=params['working_size'],
+#         with_replacement=True,
+#         mmap_mode='r')
+
+#     obs = benchmark(next, sampler)
+#     assert obs.shape == tuple(params['slice'])
+


### PR DESCRIPTION
- Have base function done for without zmq vs with zmq
- Due to pescador [zmq align bug](https://github.com/bmcfee/pescador/issues/22), only doing zmq_stream _with_ copy right now... although it's a manual copy using `np.array`.
